### PR TITLE
Allow MCMCChains v4.0.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [compat]
 Compat = "2.2"
 Documenter = "0.24"
-MCMCChains = "3.0"
+MCMCChains = "3.0, 4.0"
 StatsPlots = "0.13, 0.14"
 julia = "^1"
 


### PR DESCRIPTION
It appears the new version of MCMCChains doesn't break anything, so would be nice to allow it.