### PR TITLE
Call jags with full paths to files to avoid changing working directory

### DIFF
--- a/src/jagscode.jl
+++ b/src/jagscode.jl
@@ -11,11 +11,7 @@ function jags(
   updateinitfiles::Bool=true
   )
 
-  old = pwd()
-
   try
-    cd(ProjDir)
-
     if updatedatafile
       if length(keys(data)) > 0
         print("\nCreating data file $(model.name)-data.R - ")
@@ -34,16 +30,12 @@ function jags(
     end
 
     println()
-    curdir = pwd()
-    cd(model.tmpdir)
     println("Executing $(model.ncommands) command(s), each with $(model.nchains) chain(s) took:")
     @time run(pipeline(par(model.command), stdout="$(model.name)-run.log"))
     sim = mchain(model)
-    cd(old)
     return(sim)
   catch e
     println(e)
-    cd(old)
   end
 end
 

--- a/src/jagsmodel.jl
+++ b/src/jagsmodel.jl
@@ -52,7 +52,7 @@ function Jagsmodel(;
   else
     println("No proper model defined.")
   end
-  model_file = "$(name).bugs"
+  model_file = joinpath(pdir, "$(name).bugs")
 
   # Remove old files created by previous runs
   for i in 1:ncommands
@@ -136,12 +136,13 @@ function update_jags_file(model::Jagsmodel)
   if model.deviance || model.dic || model.popt
     jagsstr = jagsstr*"load dic\n"
   end
-  jagsstr = jagsstr*"model in $(model.model_file)\n"
-  jagsstr = jagsstr*"data in $(model.data_file)\n"
+  modelfile = joinpath(model.tmpdir, basename(model.model_file))
+  jagsstr = jagsstr* "model in $(modelfile)\n"
+  jagsstr = jagsstr*"data in $(joinpath(model.tmpdir, model.data_file))\n"
   jagsstr = jagsstr*"compile, nchains($(model.nchains))\n"
   for i in 1:model.nchains
     fname = "$(model.name)-inits$(i).R"
-    jagsstr = jagsstr*"parameters in $(fname), chain($(i))\n"
+    jagsstr = jagsstr*"parameters in $(joinpath(model.tmpdir, fname)), chain($(i))\n"
   end
   jagsstr = jagsstr*"initialize\n"
   jagsstr = jagsstr*"update $(model.adapt)\n"
@@ -161,7 +162,7 @@ function update_jags_file(model::Jagsmodel)
     end
   end
   jagsstr = jagsstr*"update $(model.nsamples)\n"
-  jagsstr = jagsstr*"coda *, stem($(model.name)-cmd1-)\n"
+  jagsstr = jagsstr*"coda *, stem($(joinpath(model.tmpdir, model.name))-cmd1-)\n"
   jagsstr = jagsstr*"exit\n"
   check_jags_file(joinpath(model.tmpdir, "$(model.name)-cmd1.jags"), jagsstr)
 end
@@ -176,8 +177,8 @@ function update_jags_file(model::Jagsmodel, cmd::Int)
   if model.deviance || model.dic || model.popt
     jagsstr = jagsstr*"load dic\n"
   end
-  jagsstr = jagsstr*"model in $(model.model_file)\n"
-  jagsstr = jagsstr*"data in $(model.data_file)\n"
+  jagsstr = jagsstr* "model in " * joinpath(model.tmpdir,  basename(model.model_file)) * "\n"
+  jagsstr = jagsstr*"data in $(joinpath(model.tmpdir, model.data_file))\n"
   jagsstr = jagsstr*"compile, nchains($(model.nchains))\n"
   for i in 1:model.nchains
     fname = "$(model.name)-inits$(indx[i]).R"
@@ -201,7 +202,7 @@ function update_jags_file(model::Jagsmodel, cmd::Int)
     end
   end
   jagsstr = jagsstr*"update $(model.nsamples)\n"
-  jagsstr = jagsstr*"coda *, stem($(model.name)-cmd$(cmd)-)\n"
+  jagsstr = jagsstr*"coda *, stem($(joinpath(model.tmpdir, model.name))-cmd$(cmd)-)\n"
   jagsstr = jagsstr*"exit\n"
   check_jags_file(joinpath(model.tmpdir, "$(model.name)-cmd$(cmd).jags"), jagsstr)
 end

--- a/src/jagsmodel.jl
+++ b/src/jagsmodel.jl
@@ -38,6 +38,7 @@ function Jagsmodel(;
   updatejagsfile::Bool=true,
   pdir::String=pwd())
 
+  old = pwd()
   cd(pdir)
 
   tmpdir = joinpath(pdir, "tmp")
@@ -109,7 +110,7 @@ function Jagsmodel(;
       updatejagsfile && update_jags_file(jm, i)
     end
   end
-
+  cd(old)
   jm
 end
 

--- a/src/jagsmodel.jl
+++ b/src/jagsmodel.jl
@@ -38,9 +38,6 @@ function Jagsmodel(;
   updatejagsfile::Bool=true,
   pdir::String=pwd())
 
-  old = pwd()
-  cd(pdir)
-
   tmpdir = joinpath(pdir, "tmp")
   @show tmpdir
   if !isdir(tmpdir)
@@ -72,7 +69,7 @@ function Jagsmodel(;
   # Create the command array which will be executed in parallel
   cmdarray = fill(``, ncommands)
   for i in 1:ncommands
-    jfile = "$(name)-cmd$(i).jags"
+    jfile = joinpath(tmpdir, "$(name)-cmd$(i).jags")
     cmdarray[i] = @static Sys.iswindows() ? `cmd /c jags $(jfile)` : `jags $(jfile)`
   end
 
@@ -88,7 +85,7 @@ function Jagsmodel(;
     println("No monitors defined!")
   end
 
-  data_file = "$(name)-data.R"
+  data_file = joinpath(tmpdir, "$(name)-data.R")
 
   jm = Jagsmodel(name,
     ncommands, nchains,
@@ -110,7 +107,6 @@ function Jagsmodel(;
       updatejagsfile && update_jags_file(jm, i)
     end
   end
-  cd(old)
   jm
 end
 

--- a/src/jagsmodel.jl
+++ b/src/jagsmodel.jl
@@ -181,7 +181,7 @@ function update_jags_file(model::Jagsmodel, cmd::Int)
   jagsstr = jagsstr*"data in $(joinpath(model.tmpdir, model.data_file))\n"
   jagsstr = jagsstr*"compile, nchains($(model.nchains))\n"
   for i in 1:model.nchains
-    fname = "$(model.name)-inits$(indx[i]).R"
+    fname = joinpath(model.tmpdir, "$(model.name)-inits$(indx[i]).R")
     jagsstr = jagsstr*"parameters in $(fname), chain($(i))\n"
   end
   jagsstr = jagsstr*"initialize\n"

--- a/src/jagsmodel.jl
+++ b/src/jagsmodel.jl
@@ -137,12 +137,12 @@ function update_jags_file(model::Jagsmodel)
     jagsstr = jagsstr*"load dic\n"
   end
   modelfile = joinpath(model.tmpdir, basename(model.model_file))
-  jagsstr = jagsstr* "model in $(modelfile)\n"
-  jagsstr = jagsstr*"data in $(joinpath(model.tmpdir, model.data_file))\n"
+  jagsstr = jagsstr* "model in \"$(modelfile)\"\n"
+  jagsstr = jagsstr*"data in \"$(joinpath(model.tmpdir, model.data_file))\"\n"
   jagsstr = jagsstr*"compile, nchains($(model.nchains))\n"
   for i in 1:model.nchains
     fname = "$(model.name)-inits$(i).R"
-    jagsstr = jagsstr*"parameters in $(joinpath(model.tmpdir, fname)), chain($(i))\n"
+    jagsstr = jagsstr*"parameters in \"$(joinpath(model.tmpdir, fname))\", chain($(i))\n"
   end
   jagsstr = jagsstr*"initialize\n"
   jagsstr = jagsstr*"update $(model.adapt)\n"
@@ -162,7 +162,7 @@ function update_jags_file(model::Jagsmodel)
     end
   end
   jagsstr = jagsstr*"update $(model.nsamples)\n"
-  jagsstr = jagsstr*"coda *, stem($(joinpath(model.tmpdir, model.name))-cmd1-)\n"
+  jagsstr = jagsstr*"coda *, stem(\"$(joinpath(model.tmpdir, model.name))-cmd1-\")\n"
   jagsstr = jagsstr*"exit\n"
   check_jags_file(joinpath(model.tmpdir, "$(model.name)-cmd1.jags"), jagsstr)
 end
@@ -177,12 +177,12 @@ function update_jags_file(model::Jagsmodel, cmd::Int)
   if model.deviance || model.dic || model.popt
     jagsstr = jagsstr*"load dic\n"
   end
-  jagsstr = jagsstr* "model in " * joinpath(model.tmpdir,  basename(model.model_file)) * "\n"
-  jagsstr = jagsstr*"data in $(joinpath(model.tmpdir, model.data_file))\n"
+  jagsstr = jagsstr* "model in \"" * joinpath(model.tmpdir,  basename(model.model_file)) * "\"\n"
+  jagsstr = jagsstr*"data in \"$(joinpath(model.tmpdir, model.data_file))\"\n"
   jagsstr = jagsstr*"compile, nchains($(model.nchains))\n"
   for i in 1:model.nchains
     fname = joinpath(model.tmpdir, "$(model.name)-inits$(indx[i]).R")
-    jagsstr = jagsstr*"parameters in $(fname), chain($(i))\n"
+    jagsstr = jagsstr*"parameters in \"$(fname)\", chain($(i))\n"
   end
   jagsstr = jagsstr*"initialize\n"
   jagsstr = jagsstr*"update $(model.adapt)\n"
@@ -202,7 +202,7 @@ function update_jags_file(model::Jagsmodel, cmd::Int)
     end
   end
   jagsstr = jagsstr*"update $(model.nsamples)\n"
-  jagsstr = jagsstr*"coda *, stem($(joinpath(model.tmpdir, model.name))-cmd$(cmd)-)\n"
+  jagsstr = jagsstr*"coda *, stem(\"$(joinpath(model.tmpdir, model.name))-cmd$(cmd)-\")\n"
   jagsstr = jagsstr*"exit\n"
   check_jags_file(joinpath(model.tmpdir, "$(model.name)-cmd$(cmd).jags"), jagsstr)
 end

--- a/test/test_bones1.jl
+++ b/test/test_bones1.jl
@@ -1,14 +1,9 @@
 ProjDir = joinpath(dirname(@__FILE__), "..", "Examples", "Bones1")
-cd(ProjDir) do
-
-println("Moving to directory: $(ProjDir)")
-
-isdir("tmp") &&
-  rm("tmp", recursive=true);
+tmpdir = joinpath(ProjDir, "tmp")
+isdir(tmpdir) &&
+  rm(tmpdir, recursive=true);
 
 include(joinpath(ProjDir, "jbones1.jl"))
 
-isdir("tmp") &&
-  rm("tmp", recursive=true);
-
-end #cd
+isdir(tmpdir) &&
+  rm(tmpdir, recursive=true);

--- a/test/test_bones2.jl
+++ b/test/test_bones2.jl
@@ -1,15 +1,10 @@
 ProjDir = joinpath(dirname(@__FILE__), "..", "Examples", "Bones2")
-cd(ProjDir) do
-  
-  println("Moving to directory: $(ProjDir)")
 
-  isfile("tmp") &&
-    rm("tmp");
+isfile(tmpdir) &&
+    rm(tmpdir);
 
   include(joinpath(ProjDir, "jbones2.jl"))
 
-  isdir("tmp") &&
-    rm("tmp", recursive=true);
-
-end
+  isdir(tmpdir) &&
+    rm(tmpdir, recursive=true);
 

--- a/test/test_cmd.jl
+++ b/test/test_cmd.jl
@@ -1,5 +1,6 @@
 ProjDir = dirname(@__FILE__)
-cd(ProjDir) do
+tmpdir = joinpath(ProjDir, "tmp")
+
 
   inits1 = [
     Dict("alpha" => 0,"beta" => 0,"tau" => 1),
@@ -63,8 +64,6 @@ cd(ProjDir) do
   println("\nInput initial values dictionary:")
   inits |> display
 
-  cd(ProjDir)
-  isdir("tmp") &&
-    rm("tmp", recursive=true);
-
-end
+  
+  isdir(tmpdir) &&
+    rm(tmpdir, recursive=true);

--- a/test/test_dyes.jl
+++ b/test/test_dyes.jl
@@ -1,14 +1,9 @@
 ProjDir = joinpath(dirname(@__FILE__), "..", "Examples", "Dyes")
-cd(ProjDir) do
-
-  println("Moving to directory: $(ProjDir)")
-
-  isdir("tmp") &&
-    rm("tmp", recursive=true);
+tmpdir = joinpath(ProjDir, "tmp")
+  isdir(tmpdir) &&
+    rm(tmpdir, recursive=true);
 
   include(joinpath(ProjDir, "jdyes.jl"))
 
-  isdir("tmp") &&
-    rm("tmp", recursive=true);
-
-end
+  isdir(tmpdir) &&
+    rm(tmpdir, recursive=true);

--- a/test/test_line1.jl
+++ b/test/test_line1.jl
@@ -1,14 +1,11 @@
 ProjDir = joinpath(dirname(@__FILE__), "..", "Examples", "Line1")
-cd(ProjDir) do
+tmpdir = joinpath(ProjDir, "tmp")
 
-  println("Moving to directory: $(ProjDir)")
-
-  isdir("tmp") &&
-    rm("tmp", recursive=true);
+  isdir(tmpdir) &&
+    rm(tmpdir, recursive=true);
 
   include(joinpath(ProjDir, "jline1.jl"))
 
-  isdir("tmp") &&
-    rm("tmp", recursive=true);
+  isdir(tmpdir) &&
+    rm(tmpdir, recursive=true);
 
-end

--- a/test/test_line2.jl
+++ b/test/test_line2.jl
@@ -1,14 +1,11 @@
 ProjDir = joinpath(dirname(@__FILE__), "..", "Examples", "Line2")
-cd(ProjDir) do
-
-  println("Moving to directory: $(ProjDir)")
-
-  isdir("tmp") &&
-    rm("tmp", recursive=true);
+tmpdir = joinpath(ProjDir, "tmp")
+  
+  isdir(tmpdir) &&
+    rm(tmpdir, recursive=true);
 
   include(joinpath(ProjDir, "jline2.jl"))
 
-  isdir("tmp") &&
-    rm("tmp", recursive=true);
+  isdir(tmpdir) &&
+    rm(tmpdir, recursive=true);
 
-end

--- a/test/test_line3.jl
+++ b/test/test_line3.jl
@@ -1,14 +1,10 @@
 ProjDir = joinpath(dirname(@__FILE__), "..", "Examples", "Line3")
-cd(ProjDir) do
+tmpdir = joinpath(ProjDir, "tmp")
 
-  println("Moving to directory: $(ProjDir)")
-
-  isdir("tmp") &&
-    rm("tmp", recursive=true);
+  isdir(tmpdir) &&
+    rm(tmpdir, recursive=true);
 
   include(joinpath(ProjDir, "jline3.jl"))
 
-  isdir("tmp") &&
-    rm("tmp", recursive=true);
-
-end
+  isdir(tmpdir) &&
+    rm(tmpdir, recursive=true);

--- a/test/test_line4.jl
+++ b/test/test_line4.jl
@@ -1,14 +1,11 @@
 ProjDir = joinpath(dirname(@__FILE__), "..", "Examples", "Line4")
-cd(ProjDir) do
+tmpdir = joinpath(ProjDir, "tmp")
 
-  println("Moving to directory: $(ProjDir)")
-
-  isdir("tmp") &&
-    rm("tmp", recursive=true);
+  isdir(tmpdir) &&
+    rm(tmpdir, recursive=true);
 
   include(joinpath(ProjDir, "jline4.jl"))
 
-  isdir("tmp") &&
-    rm("tmp", recursive=true);
+  isdir(tmpdir) &&
+    rm(tmpdir, recursive=true);
 
-end

--- a/test/test_rats.jl
+++ b/test/test_rats.jl
@@ -1,14 +1,11 @@
 ProjDir = joinpath(dirname(@__FILE__), "..", "Examples", "Rats")
-cd(ProjDir) do
+tmpdir = joinpath(ProjDir, "tmp")
   
-  println("Moving to directory: $(ProjDir)")
-
-  isdir("tmp") &&
-    rm("tmp", recursive=true);
+  isdir(tmpdir) &&
+    rm(tmpdir, recursive=true);
 
   include(joinpath(ProjDir, "jrats.jl"))
 
-  isdir("tmp") &&
-    rm("tmp", recursive=true);
+  isdir(tmpdir) &&
+    rm(tmpdir, recursive=true);
 
-end


### PR DESCRIPTION
I worked on this earlier this year, then forgot about it.

Jags.jl was changing pwd and in some cases did not change back to the original. I first fixed this issue, but then figured it would be better to call jags with full paths instead. What do you think?